### PR TITLE
First draft of an automatic key generation

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -1,0 +1,163 @@
+/*
+beacon.go hold the core of the beacon code.
+Every t seconds, it picks a point on the curve P-256 and adds it to a
+JSON storing all its commitements by using bjson.go.
+For now the compatibilty with the existing file commitments-p256.json
+is not implemented yet.
+**This code is a draft of automatization of the process of generating
+the commitements.**
+*/
+
+package beacon
+
+import (
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"sync"
+	"time"
+)
+
+var curve = elliptic.P256()
+
+//G is the base point of the curve defined above
+var G = BasePoint()
+
+//BasePoint return G
+func BasePoint() *Point {
+	one := make([]byte, 32)
+	one[31] = 1
+	x, y := curve.ScalarBaseMult(one)
+	return &Point{x, y}
+}
+
+// Point holds the coordinates of a point
+type Point struct {
+	x *big.Int
+	y *big.Int
+}
+
+// Beacon holds info related to a specific beacon
+type Beacon struct {
+	ticker *time.Ticker
+	round  uint64
+	close  chan bool
+	sync.Mutex
+	// TODO: add a field for public/private key pair
+	commitsFile string
+}
+
+// NewBeacon creates a Beacon
+func NewBeacon(address string) *Beacon {
+	commitsFile := "beacon/commits.json"
+	skeleton := `{"CF":{}, "HC":{}}`
+	err := ioutil.WriteFile(commitsFile, []byte(skeleton), 0777)
+	if err != nil {
+		print("could not create file")
+	}
+	//TODO: create keys
+
+	return &Beacon{
+		close:       make(chan bool),
+		round:       0,
+		commitsFile: commitsFile,
+	}
+}
+
+// Loop makes a beacon call run every x seconds
+func (b *Beacon) Loop(period time.Duration) {
+	b.Lock()
+	b.ticker = time.NewTicker(period)
+	b.Unlock()
+
+	var goToNextRound = true
+	var currentRoundFinished bool
+
+	//this channel is used by run to notify loop when done
+	doneCh := make(chan uint64)
+	//this channel is used by loop to stop run if needed
+	closingCh := make(chan bool)
+
+	for {
+
+		if goToNextRound {
+			//tell run to stop
+			close(closingCh)
+			closingCh = make(chan bool)
+			round := b.nextRound()
+			go b.run(round, doneCh, closingCh)
+			goToNextRound = false
+			currentRoundFinished = false
+		}
+
+		select {
+		//beacon was stopped
+		case <-b.close:
+			goToNextRound = false
+			close(closingCh)
+			close(doneCh)
+			return
+
+		//period is over
+		case <-b.ticker.C:
+			if !currentRoundFinished {
+				close(closingCh)
+			}
+			goToNextRound = true
+			continue
+
+		//run is done
+		case roundCh := <-doneCh:
+			if roundCh != b.round {
+				continue
+			}
+			currentRoundFinished = true
+		}
+	}
+}
+
+// nextRound increase the round counter
+func (b *Beacon) nextRound() uint64 {
+	b.Lock()
+	b.round++
+	b.Unlock()
+	return b.round
+}
+
+// run creates committements and prints them
+func (b *Beacon) run(round uint64, doneCh chan uint64, closingCh chan bool) {
+	select {
+	case <-closingCh:
+		return
+	default:
+		k, _ := rand.Int(rand.Reader, curve.Params().N)
+		x, y := curve.ScalarBaseMult(k.Bytes())
+		H := &Point{
+			x: x,
+			y: y,
+		}
+		//print round info
+		fmt.Printf("Round: %d\n", round)
+		fmt.Printf("G: (%v, %v)\n", G.x, G.y)
+		fmt.Printf("H: (%v, %v)\n", H.x, H.y)
+		fmt.Printf("k: %v\n", k)
+		if err := b.AddCommit(k, H); err != nil {
+			print(err)
+		}
+		//TODO: Sign the file after adding new commits
+		doneCh <- round
+	}
+}
+
+// Stop stops the beacon
+func (b *Beacon) Stop() {
+	b.Lock()
+	close(b.close)
+	if b.ticker != nil {
+		b.ticker.Stop()
+	}
+	b.Unlock()
+	fmt.Printf("Beacon stopped after %d rounds \n", b.round)
+}

--- a/beacon/bjson.go
+++ b/beacon/bjson.go
@@ -1,0 +1,75 @@
+/*
+This file is used by a beacon to modify the JSON file collecting its commitments
+*/
+
+package beacon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+)
+
+//JSONCommit hold one commit where the version is the round
+type JSONCommit struct {
+	Version struct {
+		G string `json:"G"`
+		H string `json:"H"`
+	}
+}
+
+//JSONFile holds the commitments-p256.json file in dict format
+type JSONFile struct {
+	CF JSONCommit `json:"CF"`
+	HC JSONCommit `json:"HC"`
+}
+
+// AddCommit adds the generated commitements to the json file of the beacon
+// For now we cannot concatenate commits, so it overwrites it. TODO !
+// Also need to dig in to understand the HC / CF commits differences
+func (b *Beacon) AddCommit(k *big.Int, H *Point) error {
+	//open file
+	jsonFile, err := os.Open(b.commitsFile)
+	if err != nil {
+		print("could not load commit file")
+	}
+	defer jsonFile.Close()
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		print("err reding file")
+	}
+	//store it in dict
+	res := JSONFile{}
+	json.Unmarshal(byteValue, &res)
+	//modify the json
+	gstr := b.PointToString(G)
+	hstr := b.PointToString(H)
+	res.CF.Version.G, res.HC.Version.G = gstr, gstr
+	res.CF.Version.H, res.HC.Version.H = hstr, hstr
+	final := b.JSONFileToString(res)
+	//write it back
+	err = ioutil.WriteFile(b.commitsFile, []byte(final), 0777)
+	if err != nil {
+		print("Could not write the new commits")
+	}
+	return nil
+}
+
+// JSONFileToString corrects the version and return a string
+func (b *Beacon) JSONFileToString(d JSONFile) string {
+	version := strconv.Itoa(int(b.round))
+	res2, _ := json.MarshalIndent(d, "", "    ")
+	//for now we have only one commit at a time, this should change
+	//when we modify the code to concatenate more TODO
+	return strings.Replace(string(res2), "Version", version, 2)
+}
+
+// PointToString take a point and creates matching string to wite in JSON jsonFile
+// TODO: compatibilty with existing JSON
+func (b *Beacon) PointToString(p *Point) string {
+	return fmt.Sprintf("%#v", p)
+}

--- a/beacon/commits.json
+++ b/beacon/commits.json
@@ -1,0 +1,14 @@
+{
+    "CF": {
+        "2": {
+            "G": "\u0026beacon.Point{x:(*big.Int)(0xc00000a5c0), y:(*big.Int)(0xc00000a5e0)}",
+            "H": "\u0026beacon.Point{x:(*big.Int)(0xc000096240), y:(*big.Int)(0xc000096260)}"
+        }
+    },
+    "HC": {
+        "2": {
+            "G": "\u0026beacon.Point{x:(*big.Int)(0xc00000a5c0), y:(*big.Int)(0xc00000a5e0)}",
+            "H": "\u0026beacon.Point{x:(*big.Int)(0xc000096240), y:(*big.Int)(0xc000096260)}"
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"time"
+
+	"./beacon"
+)
+
+func main() {
+	//creates and starts a new Beacon that print a new commitement every 10 seconds
+	//the beacon is stopped after 25 sec, meaning after 3 outputs
+	b := beacon.NewBeacon("localhost")
+	period := time.Duration(10) * time.Second
+	go b.Loop(period)
+	time.Sleep(time.Duration(25) * time.Second)
+	b.Stop()
+}


### PR DESCRIPTION
This PR addresses the problem of the manual commitment generation. However, due to time constraints, this is still a draft and does not implement every functionality nor is well tested. Feel free to use this code and to modify it.

Attempt at a list of that needs to be rethought, enhanced, or even redone:

- Allow concatenation of commitments in the JSON instead of overwriting the last commitment 
- Generate different commitments for CF and HC, and change the JSON in consequence
- Encode a point such that we have compatibility with existing JSON
- Generate public/private key pair and sign the commitment file
- Upload the JSON somewhere accessible by clients (gRPC?)
- Tests (!)