### PR TITLE
Add EC commitments for version 2.21

### DIFF
--- a/commitments-p256.json
+++ b/commitments-p256.json
@@ -114,6 +114,11 @@
             "expiry": "2020-12-01T00:01:00.011217546Z",
             "sig": "MEUCIQDbAFNKlGAH4Wfxf7jUPmX25PKGXdQW0Eq7ZAuCDvKCkAIgVgk+ltr35jj6vFLvrByQCYO5NweemdWxR2O/K8TmpLg="
         },
+        "2.21": {
+            "H": "BGdrUFnWM32snl9SPA4RpUtDuyIpmqVCO5R2ZNYCRxg9ids3dR14zSaLNkGcglIHTUH3hbbhcT67w1gVSJ86KIs=",
+            "expiry": "2020-12-16T00:01:00.000539046Z",
+            "sig": "MEYCIQCIqXJDsxT+v1F31vjHNUD10Iq5uEj3JOpYgZia6tobpAIhAJ2mXYICYmzxlnzJuoo2a8hvdnFMSjbebW9vPUapQq43"
+        },
         "dev": {
             "G": "BCyENEmEdWz3Wivy7iwXFcLZ0xOW7PCe2BtoMD6sYBqUK+PBZad5euc1tP9ekcdSDxxK3ijgHsQ1PqQim4VqDGo=",
             "H": "BJj8hRLfPSe+GNfbS3Jd2XmYU3XTEJw+TaTxx7M9lxVY9BDI6toWVpmffMR0P28XJcV3W0SGWX2OOrRLaBYGhwM="


### PR DESCRIPTION
Updates the commitments file for curve p256 to version 2.21 for the CF configuration