### PR TITLE
Add EC commitments for version 2.27

### DIFF
--- a/commitments-p256.json
+++ b/commitments-p256.json
@@ -144,6 +144,11 @@
             "expiry": "2021-03-03T00:01:00.011804144Z",
             "sig": "MEUCIHrlL8CCJ3xYjjCZfO5BnnkN8wB2RaO3rf0BIjfU3OZkAiEAumuGZWmeOxVGj1GJk0cB2QPy+LFqmr/WM90qLbHcbNA="
         },
+        "2.27": {
+            "H": "BC/m8Rvux9xG/cNCGkcFUSbipE8PUJ/65vtGh0U6cXLlf5wcix4eJdwmkWr4Z7N1kjglQ1Gp5XCISOMT45LCCes=",
+            "expiry": "2021-03-18T00:01:00.012376001Z",
+            "sig": "MEYCIQDH22kl4a62hyXTmSkh1xF4+f3VrBjLN3zRWYOGy6e4JgIhAKeewBBiJ7U5MdC4fyI/CV89GVjYEvltolXuiutIg+n5"
+        },
         "dev": {
             "G": "BCyENEmEdWz3Wivy7iwXFcLZ0xOW7PCe2BtoMD6sYBqUK+PBZad5euc1tP9ekcdSDxxK3ijgHsQ1PqQim4VqDGo=",
             "H": "BJj8hRLfPSe+GNfbS3Jd2XmYU3XTEJw+TaTxx7M9lxVY9BDI6toWVpmffMR0P28XJcV3W0SGWX2OOrRLaBYGhwM="


### PR DESCRIPTION
Updates the commitments file for curve p256 to version 2.27 for the CF configuration