### PR TITLE
Add EC commitments for version 2.28

### DIFF
--- a/commitments-p256.json
+++ b/commitments-p256.json
@@ -149,6 +149,11 @@
             "expiry": "2021-03-18T00:01:00.012376001Z",
             "sig": "MEYCIQDH22kl4a62hyXTmSkh1xF4+f3VrBjLN3zRWYOGy6e4JgIhAKeewBBiJ7U5MdC4fyI/CV89GVjYEvltolXuiutIg+n5"
         },
+        "2.28": {
+            "H": "BJwl5es2Citbhdu5ciGBg1UDIyO3NNlJKF+Zvg1FrV28t/lt1fTYKsBkANfp8VzLYkRhpd96Ij5GCmYkGLaQ7AE=",
+            "expiry": "2021-04-03T00:01:00.015039743Z",
+            "sig": "MEQCIHC+Rc6TW+eK4eWX8e4TwlSyf37BkNAt9a58Vhytg27SAiBBCO7neopA8aQhTN/eZjB1ZZvamcx1F1RZzT5s2oLWYA=="
+        },
         "dev": {
             "G": "BCyENEmEdWz3Wivy7iwXFcLZ0xOW7PCe2BtoMD6sYBqUK+PBZad5euc1tP9ekcdSDxxK3ijgHsQ1PqQim4VqDGo=",
             "H": "BJj8hRLfPSe+GNfbS3Jd2XmYU3XTEJw+TaTxx7M9lxVY9BDI6toWVpmffMR0P28XJcV3W0SGWX2OOrRLaBYGhwM="


### PR DESCRIPTION
Updates the commitments file for curve p256 to version 2.28 for the CF configuration